### PR TITLE
Add Capture Length to the Table

### DIFF
--- a/src/UI/Components/CaptureTab.cs
+++ b/src/UI/Components/CaptureTab.cs
@@ -41,11 +41,12 @@ public class CaptureTab
     {
         var tableFlags = ImGuiTableFlags.Borders | ImGuiTableFlags.Resizable | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY | ImGuiTableFlags.ScrollX;// | ImGuiTableFlags.SizingFixedFit;
 		
-		if (ImGui.BeginTable("CapturesTable##cf_capturetab", 8, tableFlags))
+		if (ImGui.BeginTable("CapturesTable##cf_capturetab", 9, tableFlags))
 		{
 			ImGui.TableSetupColumn("Capture ID", ImGuiTableColumnFlags.WidthFixed);
 			ImGui.TableSetupColumn("Start Time", ImGuiTableColumnFlags.WidthFixed);
 			ImGui.TableSetupColumn("End Time", ImGuiTableColumnFlags.WidthFixed);
+			ImGui.TableSetupColumn("Length", ImGuiTableColumnFlags.WidthFixed);
 			ImGui.TableSetupColumn("Uploaded", ImGuiTableColumnFlags.WidthFixed);
 			ImGui.TableSetupColumn("Ignored", ImGuiTableColumnFlags.WidthFixed);
 			ImGui.TableSetupColumn("Upload", ImGuiTableColumnFlags.WidthFixed);
@@ -58,10 +59,10 @@ public class CaptureTab
 
 			var canUpload = !string.IsNullOrEmpty(_config.AccessToken) && _config.TokenExpiryTime > DateTime.UtcNow;
 
-			foreach (var guid in _captureManager.CapturesByTime)
-			{
+			foreach (var guid in _captureManager.CapturesByTime) {
 				var captureStartTime = _captureManager.GetStartTime(guid)!.Value;
 				var captureEndTime = _captureManager.GetEndTime(guid)!.Value;
+				var length = captureEndTime - captureStartTime;
 				var uploaded = _captureManager.GetUploaded(guid)!.Value;
 				var ignored = _captureManager.GetIgnored(guid)!.Value;
 				var capturing = _captureManager.GetCapturing(guid)!.Value;
@@ -74,6 +75,8 @@ public class CaptureTab
 				ImGui.TableNextColumn();
 				var captureEndString = captureEndTime == DateTime.UnixEpoch ? "In Progress" : captureEndTime.ToLocalTime().ToString(CultureInfo.CurrentCulture); 
 				ImGui.TextUnformatted(captureEndString);
+				ImGui.TableNextColumn();
+				ImGui.TextUnformatted(string.Format("{0:00}:{1:00}:{2:00}", Math.Floor(length.TotalHours), length.Minutes, length.Seconds));
 				ImGui.TableNextColumn();
 				ImGui.TextUnformatted(uploaded ? "Yes" : "No");
 				ImGui.TableNextColumn();

--- a/src/UI/Components/CaptureTab.cs
+++ b/src/UI/Components/CaptureTab.cs
@@ -59,7 +59,8 @@ public class CaptureTab
 
 			var canUpload = !string.IsNullOrEmpty(_config.AccessToken) && _config.TokenExpiryTime > DateTime.UtcNow;
 
-			foreach (var guid in _captureManager.CapturesByTime) {
+			foreach (var guid in _captureManager.CapturesByTime)
+			{
 				var captureStartTime = _captureManager.GetStartTime(guid)!.Value;
 				var captureEndTime = _captureManager.GetEndTime(guid)!.Value;
 				var length = captureEndTime - captureStartTime;

--- a/src/UI/Components/CaptureTab.cs
+++ b/src/UI/Components/CaptureTab.cs
@@ -67,17 +67,20 @@ public class CaptureTab
 				var uploaded = _captureManager.GetUploaded(guid)!.Value;
 				var ignored = _captureManager.GetIgnored(guid)!.Value;
 				var capturing = _captureManager.GetCapturing(guid)!.Value;
-				
+
+				var captureInProgress = captureEndTime == DateTime.UnixEpoch;
+
 				ImGui.TableNextRow();
 				ImGui.TableNextColumn();
 				ImGui.TextUnformatted(guid.ToString());
 				ImGui.TableNextColumn();
 				ImGui.TextUnformatted(captureStartTime.ToLocalTime().ToString(CultureInfo.CurrentCulture));
 				ImGui.TableNextColumn();
-				var captureEndString = captureEndTime == DateTime.UnixEpoch ? "In Progress" : captureEndTime.ToLocalTime().ToString(CultureInfo.CurrentCulture); 
+				var captureEndString = captureInProgress ? "In Progress" : captureEndTime.ToLocalTime().ToString(CultureInfo.CurrentCulture); 
 				ImGui.TextUnformatted(captureEndString);
 				ImGui.TableNextColumn();
-				ImGui.TextUnformatted(string.Format("{0:00}:{1:00}:{2:00}", Math.Floor(length.TotalHours), length.Minutes, length.Seconds));
+				var lengthStr = captureInProgress ? "In Progress" : string.Format("{0:00}:{1:00}:{2:00}", Math.Floor(length.TotalHours), length.Minutes, length.Seconds);
+				ImGui.TextUnformatted(lengthStr);
 				ImGui.TableNextColumn();
 				ImGui.TextUnformatted(uploaded ? "Yes" : "No");
 				ImGui.TableNextColumn();

--- a/src/UI/Components/UploadModal.cs
+++ b/src/UI/Components/UploadModal.cs
@@ -153,7 +153,7 @@ public class UploadModal : Window
         }
 
 		var length = (captureEnd - captureStart).Value;
-        var lengthString = string.Format("{0:00}:{1:00}:{2:00}", Math.Floor(length.TotalHours), length.Minutes, length.Seconds);
+		var lengthString = string.Format("{0:00}:{1:00}:{2:00}", Math.Floor(length.TotalHours), length.Minutes, length.Seconds);
 		var startString = captureStart?.ToString(CultureInfo.InvariantCulture);
         var endString = captureEnd?.ToString(CultureInfo.InvariantCulture);
         

--- a/src/UI/Components/UploadModal.cs
+++ b/src/UI/Components/UploadModal.cs
@@ -152,10 +152,12 @@ public class UploadModal : Window
             return;
         }
 
-        var startString = captureStart?.ToString(CultureInfo.InvariantCulture);
+		var length = (captureEnd - captureStart).Value;
+        var lengthString = string.Format("{0:00}:{1:00}:{2:00}", Math.Floor(length.TotalHours), length.Minutes, length.Seconds);
+		var startString = captureStart?.ToString(CultureInfo.InvariantCulture);
         var endString = captureEnd?.ToString(CultureInfo.InvariantCulture);
         
-        ImGuiHelpers.SafeTextWrapped($"Preparing to upload capture {_captureId}, began {startString}, ended {endString}");
+        ImGuiHelpers.SafeTextWrapped($"Preparing to upload capture {_captureId}, began {startString}, ended {endString}, for a total duration of {lengthString}");
 
         ImGui.TextUnformatted("Override my normal settings for this capture upload: ");
         ImGui.SameLine();

--- a/src/UI/Components/UploadsTab.cs
+++ b/src/UI/Components/UploadsTab.cs
@@ -108,12 +108,17 @@ public class UploadsTab
         }
         else
         {
-	        if (ImGui.BeginTable("UploadsTable##cf_uploadstab", 6, tableFlags))
+			var earliestContribution = DateTime.MaxValue;
+			var latestContribution = DateTime.MinValue;
+			var accumulatedLength = new TimeSpan(0, 0, 0);
+
+	        if (ImGui.BeginTable("UploadsTable##cf_uploadstab", 7, tableFlags))
 	        {
 		        ImGui.TableSetupColumn("Capture ID", ImGuiTableColumnFlags.WidthFixed);
 		        ImGui.TableSetupColumn("Start Time", ImGuiTableColumnFlags.WidthFixed);
 		        ImGui.TableSetupColumn("End Time", ImGuiTableColumnFlags.WidthFixed);
-		        ImGui.TableSetupColumn("Metrics Time", ImGuiTableColumnFlags.WidthFixed);
+				ImGui.TableSetupColumn("Length", ImGuiTableColumnFlags.WidthFixed);
+				ImGui.TableSetupColumn("Metrics Time", ImGuiTableColumnFlags.WidthFixed);
 		        ImGui.TableSetupColumn("Public Time", ImGuiTableColumnFlags.WidthFixed);
 		        ImGui.TableSetupColumn("Delete from Server", ImGuiTableColumnFlags.WidthFixed);
 		        ImGui.TableSetupScrollFreeze(0, 1);
@@ -125,10 +130,16 @@ public class UploadsTab
 			        var guid = element.CaptureId;
 			        var captureStartStr = element.StartTime.ToLocalTime().ToString(CultureInfo.CurrentCulture);
 			        var captureEndStr = element.EndTime.ToLocalTime().ToString(CultureInfo.CurrentCulture);
-			        var metricsTimeStr = Util.GetTimeString(element.MetricsTime, element.MetricsWhenEos);
+					var length = element.EndTime.ToLocalTime() - element.StartTime.ToLocalTime();
+					var lengthStr = string.Format("{0:00}:{1:00}:{2:00}", Math.Floor(length.TotalHours), length.Minutes, length.Seconds);
+					var metricsTimeStr = Util.GetTimeString(element.MetricsTime, element.MetricsWhenEos);
 			        var publicTimeStr = Util.GetTimeString(element.PublicTime, element.PublicWhenEos);
-			        
-			        ImGui.TableNextRow();
+
+					if (earliestContribution > element.StartTime.ToLocalTime()) earliestContribution = element.StartTime.ToLocalTime();
+					if (latestContribution < element.EndTime.ToLocalTime()) latestContribution = element.EndTime.ToLocalTime();
+					accumulatedLength += length;
+
+					ImGui.TableNextRow();
 			        ImGui.TableNextColumn();
 			        ImGui.TextUnformatted(guid.ToString());
 			        ImGui.TableNextColumn();
@@ -136,7 +147,9 @@ public class UploadsTab
 			        ImGui.TableNextColumn();
 			        ImGui.TextUnformatted(captureEndStr);
 			        ImGui.TableNextColumn();
-			        ImGui.TextUnformatted(metricsTimeStr);
+					ImGui.TextUnformatted(lengthStr);
+					ImGui.TableNextColumn();
+					ImGui.TextUnformatted(metricsTimeStr);
 			        ImGui.TableNextColumn();
 			        ImGui.TextUnformatted(publicTimeStr);
 			        ImGui.TableNextColumn();
@@ -182,7 +195,23 @@ public class UploadsTab
 			        }
 		        }
 
-		        ImGui.EndTable();
+				ImGui.TableNextRow();
+				ImGui.TableNextColumn();
+				ImGui.TextUnformatted("Total contribution stats:");
+				ImGui.TableNextColumn();
+				ImGui.TextUnformatted(earliestContribution.ToString());
+				if (ImGui.IsItemHovered())
+					ImGui.SetTooltip("The first time you recorded and uploaded a session.");
+				ImGui.TableNextColumn();
+				ImGui.TextUnformatted(latestContribution.ToString());
+				if (ImGui.IsItemHovered())
+					ImGui.SetTooltip("The last time you recorded and uploaded a session.");
+				ImGui.TableNextColumn();
+				ImGui.TextUnformatted(string.Format("{0}:{1:00}:{2:00}:{3:00}", Math.Floor(accumulatedLength.TotalDays), Math.Floor(accumulatedLength.TotalHours), accumulatedLength.Minutes, accumulatedLength.Seconds));
+				if (ImGui.IsItemHovered())
+					ImGui.SetTooltip("The total accumulated Time you recorded and uploaded.");
+
+				ImGui.EndTable();
 	        }
         }
     }

--- a/src/UI/Components/UploadsTab.cs
+++ b/src/UI/Components/UploadsTab.cs
@@ -207,7 +207,7 @@ public class UploadsTab
 				if (ImGui.IsItemHovered())
 					ImGui.SetTooltip("The last time you recorded and uploaded a session.");
 				ImGui.TableNextColumn();
-				ImGui.TextUnformatted(string.Format("{0}:{1:00}:{2:00}:{3:00}", Math.Floor(accumulatedLength.TotalDays), Math.Floor(accumulatedLength.TotalHours), accumulatedLength.Minutes, accumulatedLength.Seconds));
+				ImGui.TextUnformatted(string.Format("{0}:{1:00}:{2:00}:{3:00}", Math.Floor(accumulatedLength.TotalDays), accumulatedLength.Hours, accumulatedLength.Minutes, accumulatedLength.Seconds));
 				if (ImGui.IsItemHovered())
 					ImGui.SetTooltip("The total accumulated Time you recorded and uploaded.");
 


### PR DESCRIPTION
Small addition that adds a "Length" Column to the Table in Captures and Uploads, and a little text to the upload Modal that shows the total length of the Capture. Simplifies deciding which exact ones you may want to upload and which ones delete, since restarting your game during plogon dev can generate a lot of >10 minute Captures as you most certainly know. 

While at it I felt it would be fun to add a little Statistic to the Uploads tab, I added a last row that shows the First Upload date, last upload date and the total length of all uploaded Captures. Kinda just happend while I was thinking about the entire length thing. 

Note the commit message: 
I used string.Format to display the TimeSpan because the ToString modifier breaks on times that are higher then 24 hours, and there WILL be _someone_ out there having a capture longer then that...