### PR TITLE
Fix truncated auto-upload warning

### DIFF
--- a/src/Web/Upload/AutoUploadService.cs
+++ b/src/Web/Upload/AutoUploadService.cs
@@ -48,7 +48,8 @@ public class AutoUploadService
                 {
                     Type = NotificationType.Warning,
                     Title = "Auto Upload Warning",
-                    Content = "Warning: You have auto-upload enabled, but you are not logged in to the Chronofoil Service."
+                    Content = "Warning: You have auto-upload enabled, but you are not logged in to the Chronofoil Service.",
+                    Minimized = false
                 });
             }
             


### PR DESCRIPTION
The notification only displayed "Warning: You have auto-upload enabled,", and it looked stupid. give me $200